### PR TITLE
Fixing bg for Dark Mode

### DIFF
--- a/mod_db8colors/tmpl/default.php
+++ b/mod_db8colors/tmpl/default.php
@@ -27,7 +27,7 @@ $colors = $params->get('colors', []);
     }
 
     tr:nth-child(even) {
-        background-color: #f2f2f2;
+        background-color: var(--template-quickicon-bg, #f2f2f2);
     }
 </style>
 


### PR DESCRIPTION
This adds a fix to show a less bright background color for the alt rows when using dark mode. It also adds the current value as fallback for those templates (J3?) not using the template variable.